### PR TITLE
unix, si and iec filesize units and human-readable option

### DIFF
--- a/lib/hdfsutils/output/output_stat.rb
+++ b/lib/hdfsutils/output/output_stat.rb
@@ -7,6 +7,7 @@
 #
 
 require 'pp'
+require 'units'
 
 module HdfsUtils
   #
@@ -54,7 +55,9 @@ module HdfsUtils
     end
 
     def output_size(stat)
-      sprintf('%10d', stat['length'])
+      s = HdfsUtils::Units.new.format_filesize(stat['length'],
+                                               @settings[:filesizeunits])
+      sprintf('%10s', s)
     end
 
     def output_mtime(stat)

--- a/lib/hdfsutils/settings/commandline_settings.rb
+++ b/lib/hdfsutils/settings/commandline_settings.rb
@@ -34,6 +34,9 @@ module HdfsUtils
 
     LOG_LEVELS = %w(debug info warn error fatal)
 
+    FILESIZE_UNITS = %w(bytes unix iec si)
+
+    # rubocop:disable Metrics/MethodLength
     def setup(optsproc)
       @options = OptionParser.new do |opts|
         # set up options that are specific to the utility
@@ -50,6 +53,14 @@ module HdfsUtils
           @settings[:host] = uri.host
           @settings[:port] = uri.port.to_s
           @settings[:user] = uri.userinfo
+        end
+        @settings[:filesizeunits] = 'bytes'
+        opts.on('--filesizeunits UNITS',
+                "filesizeunits: #{FILESIZE_UNITS.join(', ')}") do |units|
+          @settings[:filesizeunits] = units.downcase
+        end
+        opts.on('-h', 'Synonym for --filesizeunits unix')  do
+          @settings[:filesizeunits] = 'unix'
         end
         opts.on('--log-level LEVEL',
                 "Log level: #{LOG_LEVELS.join(', ')}") do |log_level|
@@ -72,9 +83,15 @@ module HdfsUtils
 
     # Validate the settings.
     def validate
-      return if LOG_LEVELS.include?(@settings.log_level.downcase)
-      STDERR.puts "Invalid log_level (#{@settings.log_level}).  " \
-                  "Valid values: #{LOG_LEVELS.join(', ')}\n\n"
+      unless LOG_LEVELS.include?(@settings.log_level.downcase)
+        STDERR.puts "Invalid log_level (#{@settings.log_level}).  " \
+        "Valid values: #{LOG_LEVELS.join(', ')}\n\n"
+        STDERR.puts @options
+        exit! 1
+      end
+      return if FILESIZE_UNITS.include?(@settings[:filesizeunits])
+      STDERR.puts "Invalid size units (#{@settings[:filesizeunits]}).  " \
+      "Valid values: #{FILESIZE_UNITS.join(', ')}\n\n"
       STDERR.puts @options
       exit! 1
     end

--- a/lib/hdfsutils/units.rb
+++ b/lib/hdfsutils/units.rb
@@ -1,0 +1,97 @@
+#
+# Library: units.rb
+#
+# Copyright (C) 2015 Altiscale, Inc.
+# Licensed under the Apache License, Version 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+
+module HdfsUtils
+  #
+  # Standard handling of units for input and output for all utilities
+  #
+  class Units
+    public
+
+    FILESIZE_REGEXP = /\A
+      (?<op>[\-\+]{0,1})
+      (?<num>\d+)
+      (?<unit>(c|(kB?)|(KiB)|([MGTP](i?B)?)?))
+      \z/x
+
+    UNIT_TO_BYTES = {
+      'c' => 2**0,
+      'k' => 2**10,
+      'M' => 2**20,
+      'G' => 2**30,
+      'T' => 2**40,
+      'P' => 2**50,
+      'kB' => 1000,
+      'MB' => 1000**2,
+      'GB' => 1000**3,
+      'TB' => 1000**4,
+      'PB' => 1000**5,
+      'KiB' => 2**10,
+      'MiB' => 2**20,
+      'GiB' => 2**30,
+      'TiB' => 2**40,
+      'PiB' => 2**50,
+      ''  => 512
+    }
+
+    SI_UNITS = {
+      units: %w(B kB MB GB TB PB),
+      base: 1000,
+      width: 3
+    }
+
+    IEC_UNITS = {
+      units: %w(B KiB MiB GiB TiB PiB),
+      base: 1024,
+      width: 4
+    }
+
+    UNIX_UNITS = {
+      units: %w(B K M G T P),
+      base: 1024,
+      width: 4
+    }
+
+    SYSTEM_TO_UNITS = {
+      'unix' => UNIX_UNITS,
+      'si' => SI_UNITS,
+      'iec' => IEC_UNITS
+    }
+
+    def parse_filesize(value)
+      md = FILESIZE_REGEXP.match(value)
+      fail "#{value}: invalid numeric value" unless md
+      [md['op'], md['num'].to_i, UNIT_TO_BYTES[md['unit']]]
+    end
+
+    def format_filesize(n, system = 'bytes')
+      units = SYSTEM_TO_UNITS[system]
+      return n.to_s unless units
+      return "0#{units[:units][0]}" if n == 0
+      require 'bigdecimal'
+      n = BigDecimal.new(n)
+      sign = n.sign < 0 ? '-' : ''
+      n = n.abs
+      i = 0
+      while i < units[:units].length - 1
+        break if n < units[:base]
+        n /= units[:base]
+        i += 1
+      end
+      s = n.to_i.to_s
+      if s.length < units[:width] - 1 && n.frac != 0
+        _sign, significant_digits, _base, exponent = n.split
+        s += '.' + significant_digits[exponent..-1] + '0000000000'
+        s = s[0, units[:width]]
+        s = s.sub(/\.0*$/, '.0')
+        s.chomp!('.')
+      end
+      "#{sign}#{s}#{units[:units][i]}"
+    end
+  end
+end

--- a/lib/hdfsutils/utils/hdfind/compile.rb
+++ b/lib/hdfsutils/utils/hdfind/compile.rb
@@ -186,20 +186,8 @@ module FindCompile
     [md['op'], md['num'].to_i]
   end
 
-  UNIT_TO_BYTES = {
-    'c' => 2**0,
-    'k' => 2**10,
-    'M' => 2**20,
-    'G' => 2**30,
-    'T' => 2**40,
-    'P' => 2**50,
-    ''  => 512
-  }
-
   def parse_numeric(value)
-    md = /\A(?<op>[\-\+]{0,1})(?<num>\d+)(?<unit>[ckMGTP]{0,1})\z/.match(value)
-    fail "#{value}: invalid numeric value" unless md
-    [md['op'], md['num'].to_i, UNIT_TO_BYTES[md['unit']]]
+    HdfsUtils::Units.new.parse_filesize(value)
   end
 
   #

--- a/lib/hdfsutils/utils/hdfind/options.rb
+++ b/lib/hdfsutils/utils/hdfind/options.rb
@@ -6,6 +6,8 @@
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 
+require 'units'
+
 #
 # Options for the find utility.
 #
@@ -206,7 +208,7 @@ module FindOptions
 
   def validate_numeric
     lambda do |numval|
-      return nil if numval.match(/\A[\-\+]{0,1}\d+[ckMGTP]{0,1}\z/)
+      return nil if HdfsUtils::Units::FILESIZE_REGEXP.match(numval)
       "#{numval}: illegal numeric value"
     end
   end

--- a/lib/hdfsutils/version.rb
+++ b/lib/hdfsutils/version.rb
@@ -2,5 +2,5 @@
 # Version of the gem, shared by all utilities.
 #
 module HdfsUtils
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/units/filesize_units_spec.rb
+++ b/spec/units/filesize_units_spec.rb
@@ -1,0 +1,112 @@
+#
+# Test: filesize_units_spec.rb
+#
+# Copyright (C) 2015 Altiscale, Inc.
+# Licensed under the Apache License, Version 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+
+require_relative '../spec_helper'
+require 'units.rb'
+
+describe HdfsUtils::Units do
+  PARSE_TESTS =
+    [
+      ['123', ['', 123, 512]],
+      ['123', ['', 123, 512]],
+      ['123c', ['', 123, 1]],
+      ['123k', ['', 123, 2**10]],
+      ['123M', ['', 123, 2**20]],
+      ['123G', ['', 123, 2**30]],
+      ['123T', ['', 123, 2**40]],
+      ['123P', ['', 123, 2**50]],
+      ['123kB', ['', 123, 1000]],
+      ['123MB', ['', 123, 1000**2]],
+      ['123GB', ['', 123, 1000**3]],
+      ['123TB', ['', 123, 1000**4]],
+      ['123PB', ['', 123, 1000**5]],
+      ['123KiB', ['', 123, 2**10]],
+      ['123MiB', ['', 123, 2**20]],
+      ['123GiB', ['', 123, 2**30]],
+      ['123TiB', ['', 123, 2**40]],
+      ['123PiB', ['', 123, 2**50]],
+      ['+123MiB', ['+', 123, 2**20]]
+    ]
+
+  PARSE_TESTS.each do |val, expected|
+    it "should parse #{val} correctly" do
+      expect(subject.parse_filesize(val)).to eq(expected)
+    end
+  end
+
+  NEGATIVE_PARSE_TESTS = %w(123kiB 123KB 123cB 123Mi)
+
+  NEGATIVE_PARSE_TESTS.each do |val|
+    it "should raise an error when parsing #{val}" do
+      expect { subject.parse_filesize(val) }.to raise_error(RuntimeError)
+    end
+  end
+
+  FORMAT_TESTS =
+    [
+      [-1, { 'unix' => '-1B', 'si' => '-1B', 'iec' => '-1B' }],
+      [0, { 'unix' => '0B', 'si' => '0B', 'iec' => '0B' }],
+      [1, { 'unix' => '1B', 'si' => '1B', 'iec' => '1B' }],
+      [12, { 'unix' => '12B', 'si' => '12B', 'iec' => '12B' }],
+      [123, { 'unix' => '123B', 'si' => '123B', 'iec' => '123B' }],
+      [999, { 'unix' => '999B', 'si' => '999B', 'iec' => '999B' }],
+      [1000, { 'unix' => '1000B', 'si' => '1kB', 'iec' => '1000B' }],
+      [1001, { 'unix' => '1001B', 'si' => '1.0kB', 'iec' => '1001B' }],
+      [1023, { 'unix' => '1023B', 'si' => '1.0kB', 'iec' => '1023B' }],
+      [1024, { 'unix' => '1K', 'si' => '1.0kB', 'iec' => '1KiB' }],
+      [1025, { 'unix' => '1.0K', 'si' => '1.0kB', 'iec' => '1.0KiB' }],
+      [9999, { 'unix' => '9.76K', 'si' => '9.9kB', 'iec' => '9.76KiB' }],
+      [99_999, { 'unix' => '97.6K', 'si' => '99kB', 'iec' => '97.6KiB' }],
+      [999_999, { 'unix' => '976K', 'si' => '999kB', 'iec' => '976KiB' }],
+      [1000**2 - 1, { 'unix' => '976K', 'si' => '999kB', 'iec' => '976KiB' }],
+      [1000**2, { 'unix' => '976K', 'si' => '1MB', 'iec' => '976KiB' }],
+      [1000**2 + 1, { 'unix' => '976K', 'si' => '1.0MB', 'iec' => '976KiB' }],
+      [1024**2 - 1, { 'unix' => '1023K', 'si' => '1.0MB', 'iec' => '1023KiB' }],
+      [1024**2, { 'unix' => '1M', 'si' => '1.0MB', 'iec' => '1MiB' }],
+      [1024**2 + 1, { 'unix' => '1.0M', 'si' => '1.0MB', 'iec' => '1.0MiB' }],
+      [1000**3 - 1, { 'unix' => '953M', 'si' => '999MB', 'iec' => '953MiB' }],
+      [1000**3, { 'unix' => '953M', 'si' => '1GB', 'iec' => '953MiB' }],
+      [1000**3 + 1, { 'unix' => '953M', 'si' => '1.0GB', 'iec' => '953MiB' }],
+      [1024**3 - 1, { 'unix' => '1023M', 'si' => '1.0GB', 'iec' => '1023MiB' }],
+      [1024**3, { 'unix' => '1G', 'si' => '1.0GB', 'iec' => '1GiB' }],
+      [1024**3 + 1, { 'unix' => '1.0G', 'si' => '1.0GB', 'iec' => '1.0GiB' }],
+      [1000**4 - 1, { 'unix' => '931G', 'si' => '999GB', 'iec' => '931GiB' }],
+      [1000**4, { 'unix' => '931G', 'si' => '1TB', 'iec' => '931GiB' }],
+      [1000**4 + 1, { 'unix' => '931G', 'si' => '1.0TB', 'iec' => '931GiB' }],
+      [1024**4 - 1, { 'unix' => '1023G', 'si' => '1.0TB', 'iec' => '1023GiB' }],
+      [1024**4, { 'unix' => '1T', 'si' => '1.0TB', 'iec' => '1TiB' }],
+      [1024**4 + 1, { 'unix' => '1.0T', 'si' => '1.0TB', 'iec' => '1.0TiB' }],
+      [1000**5 - 1, { 'unix' => '909T', 'si' => '999TB', 'iec' => '909TiB' }],
+      [1000**5, { 'unix' => '909T', 'si' => '1PB', 'iec' => '909TiB' }],
+      [1000**5 + 1, { 'unix' => '909T', 'si' => '1.0PB', 'iec' => '909TiB' }],
+      [1024**5 - 1, { 'unix' => '1023T', 'si' => '1.1PB', 'iec' => '1023TiB' }],
+      [1024**5, { 'unix' => '1P', 'si' => '1.1PB', 'iec' => '1PiB' }],
+      [1024**5 + 1, { 'unix' => '1.0P', 'si' => '1.1PB', 'iec' => '1.0PiB' }],
+      [1000**6 - 1, { 'unix' => '888P', 'si' => '999PB', 'iec' => '888PiB' }],
+      [1000**6, { 'unix' => '888P', 'si' => '1000PB', 'iec' => '888PiB' }],
+      [1000**6 + 1, { 'unix' => '888P', 'si' => '1000PB', 'iec' => '888PiB' }],
+      [1024**6 - 1, { 'unix' => '1023P', 'si' => '1152PB',
+                      'iec' => '1023PiB' }],
+      [1024**6, { 'unix' => '1024P', 'si' => '1152PB', 'iec' => '1024PiB' }],
+      [1024**6 + 1, { 'unix' => '1024P', 'si' => '1152PB', 'iec' => '1024PiB' }]
+    ]
+
+  FORMAT_TESTS.each do |val, canonicals|
+    canonicals.each_pair do |system, expected|
+      it "should format #{val} correctly using #{system} units" do
+        expect(subject.format_filesize(val, system)).to eq(expected)
+      end
+    end
+  end
+
+  FORMAT_TESTS.each do |val, _canonicals|
+    it "should format #{val} correctly using default units" do
+      expect(subject.format_filesize(val)).to eq(val.to_s)
+    end
+  end
+end

--- a/spec/utils/hdfind_spec.rb
+++ b/spec/utils/hdfind_spec.rb
@@ -9,6 +9,7 @@
 require_relative '../spec_helper'
 require_relative 'common_spec_webmock'
 require 'utils/hdfind/find'
+require 'units'
 
 describe HdfsUtils::Find do
   include CommonSpecWebmock
@@ -117,6 +118,129 @@ describe HdfsUtils::Find do
 
     expect do
       HdfsUtils::Find.new('find', [dirname, '-minsize', '500000k', '-ls']).run
+    end.to output(find_output).to_stdout
+  end
+
+  it 'should support unix units for size' do
+    dirname = '/user/testuser/another_testdir'
+    filename = 'another_test_101'
+    dir2name = 'another_sub_dir'
+    subdir = dirname + '/' + dir2name
+    file2name = 'another_test_102'
+    file3name = 'another_test_103'
+    common_spec_webmock(dirname: dirname,
+                        filename: filename,
+                        dir2name: dir2name,
+                        file2name: file2name,
+                        file3name: file3name)
+
+    find_output = 'drwxr-xr-x   - testuser users ' +
+                  '      617M 2015-05-15 21:03 ' +
+                  dirname + "\n" +
+                  'drwx------   - testuser users ' +
+                  '      617M 2015-05-15 21:07 ' +
+                  subdir  + "\n" +
+                  '-rwxrwxr-x   3 testuser users ' +
+                  '      361M 2015-05-15 22:28 ' +
+                  subdir  + '/' + file3name + "\n"
+
+    expect do
+      HdfsUtils::Find.new('find', [dirname, '-size', '+379334627c', '-ls',
+                                   '--filesizeunits', 'unix']).run
+    end.to output(find_output).to_stdout
+
+    find_output = 'drwxr-xr-x   - testuser users ' +
+                  '      617M 2015-05-15 21:03 ' +
+                  dirname + "\n" +
+                  'drwx------   - testuser users ' +
+                  '      617M 2015-05-15 21:07 ' +
+                  subdir  + "\n"
+
+    expect do
+      HdfsUtils::Find.new('find', [dirname, '-minsize', '500000k', '-ls',
+                                   '--filesizeunits', 'unix']).run
+    end.to output(find_output).to_stdout
+  end
+
+  it 'should support SI units for size' do
+    dirname = '/user/testuser/another_testdir'
+    filename = 'another_test_101'
+    dir2name = 'another_sub_dir'
+    subdir = dirname + '/' + dir2name
+    file2name = 'another_test_102'
+    file3name = 'another_test_103'
+    common_spec_webmock(dirname: dirname,
+                        filename: filename,
+                        dir2name: dir2name,
+                        file2name: file2name,
+                        file3name: file3name)
+
+    find_output = 'drwxr-xr-x   - testuser users ' +
+                  '     647MB 2015-05-15 21:03 ' +
+                  dirname + "\n" +
+                  'drwx------   - testuser users ' +
+                  '     647MB 2015-05-15 21:07 ' +
+                  subdir  + "\n" +
+                  '-rwxrwxr-x   3 testuser users ' +
+                  '     379MB 2015-05-15 22:28 ' +
+                  subdir  + '/' + file3name + "\n"
+
+    expect do
+      HdfsUtils::Find.new('find', [dirname, '-size', '+370MB', '-ls',
+                                   '--filesizeunits', 'si']).run
+    end.to output(find_output).to_stdout
+
+    find_output = 'drwxr-xr-x   - testuser users ' +
+                  '     647MB 2015-05-15 21:03 ' +
+                  dirname + "\n" +
+                  'drwx------   - testuser users ' +
+                  '     647MB 2015-05-15 21:07 ' +
+                  subdir  + "\n"
+
+    expect do
+      HdfsUtils::Find.new('find', [dirname, '-minsize', '500000k', '-ls',
+                                   '--filesizeunits', 'si']).run
+    end.to output(find_output).to_stdout
+  end
+
+  it 'should support IEC units for size' do
+    dirname = '/user/testuser/another_testdir'
+    filename = 'another_test_101'
+    dir2name = 'another_sub_dir'
+    subdir = dirname + '/' + dir2name
+    file2name = 'another_test_102'
+    file3name = 'another_test_103'
+    common_spec_webmock(dirname: dirname,
+                        filename: filename,
+                        dir2name: dir2name,
+                        file2name: file2name,
+                        file3name: file3name)
+
+    find_output = 'drwxr-xr-x   - testuser users ' +
+                  '    617MiB 2015-05-15 21:03 ' +
+                  dirname + "\n" +
+                  'drwx------   - testuser users ' +
+                  '    617MiB 2015-05-15 21:07 ' +
+                  subdir  + "\n" +
+                  '-rwxrwxr-x   3 testuser users ' +
+                  '    361MiB 2015-05-15 22:28 ' +
+                  subdir  + '/' + file3name + "\n"
+
+    expect do
+      HdfsUtils::Find.new('find', [dirname, '-size', '+360MiB', '-ls',
+                                   '--filesizeunits', 'iec']).run
+    end.to output(find_output).to_stdout
+
+    find_output = 'drwxr-xr-x   - testuser users ' +
+                  '    617MiB 2015-05-15 21:03 ' +
+                  dirname + "\n" +
+                  'drwx------   - testuser users ' +
+                  '    617MiB 2015-05-15 21:07 ' +
+                  subdir  + "\n"
+
+    expect do
+      HdfsUtils::Find.new('find', [dirname, '-minsize', '500000k', '-ls',
+                                   '--filesizeunits', 'iec']).run
     end.to output(find_output).to_stdout
   end
 

--- a/spec/utils/hdls_spec.rb
+++ b/spec/utils/hdls_spec.rb
@@ -129,4 +129,39 @@ describe HdfsUtils::Ls do
                          dirname]).run
     end.to output(ls_output).to_stdout
   end
+
+  it 'should support unix units for output' do
+    dirname = '/data'
+    filename = 'first_data_file'
+    dir2name = 'recursion_dir_long'
+    file2name = 'second_data_file'
+    file3name = 'third_data_file'
+    common_spec_webmock(dirname: dirname,
+                        filename: filename,
+                        dir2name: dir2name,
+                        file2name: file2name,
+                        file3name: file3name)
+
+    ls_output = '-rwxrwxr-x   3 testuser users ' +
+                '     5.67K 2015-05-15 21:04 ' +
+                filename + "\n" +
+                'drwx------   - testuser users ' +
+                '        0B 2015-05-15 21:07 ' +
+                dir2name + "\n" + "\n" +
+                dirname + '/' + dir2name + ':' + "\n" +
+                '-rwxrwxr-x   3 testuser users ' +
+                '      256M 2015-05-15 20:52 ' +
+                file2name + "\n" +
+                '-rwxrwxr-x   3 testuser users ' +
+                '      361M 2015-05-15 22:28 ' +
+                file3name + "\n"
+
+    expect do
+      HdfsUtils::Ls.new('hdls',
+                        ['-lR',
+                         '--log-level', 'debug',
+                         '--filesizeunits', 'unix',
+                         dirname]).run
+    end.to output(ls_output).to_stdout
+  end
 end


### PR DESCRIPTION
Add support for different filesize unit systems:
- 'unix' - base 1024 - compatible with ls -h and du -h - uses B K M G T P on output (but c k M G T P are still supported on input)
- 'si' - base 1000 - B kB MB GB TB PB (input and output)
- 'iec' - base 1024 - B KiB MiB GiB TiB PiB (input and output)

The algorithm for converting from raw byte numbers to units is slightly different from linux (which itself differs slightly from version to version). In summary:
- It computes the largest unit that allows a representation that is lesser or equal to the raw number: thus 1023 bytes becomes '1023B', not '1.0K' as on some linux systems
- The numeric portion is never more than 3 characters (for base-1000 systems) or 4 characters (for base 1024 systems) unless the unit is the maximum (petabytes, at present) in which case as many characters are used as needed. Thus, (1000**6) becomes 1000PB.
- It uses a decimal point only:
  - If there is room for at least one digit after decimal point. Thus 99_999 becomes 99kB
  - The fractional part is non-zero. Thus (1024**2) becomes 1M
- Like unix systems, it truncates the fractional part, removes trailing zeroes, preserving only one if immediately after the decimal point. Thus (1024**2)+1 becomes 1.0M

The behavior is extensively documented by the unit tests.

Usage (both hdfind and hdls):

```
        --filesizeunits UNITS        filesizeunits: bytes, unix, iec, si
    -h                               Synonym for --filesizeunits unix
```
